### PR TITLE
refactor: 로컬 스토리지에 담은 인증토큰이 만료되지 않고, 로그인이 유지되도록 기능 추가

### DIFF
--- a/api/user/refreshApi.ts
+++ b/api/user/refreshApi.ts
@@ -1,0 +1,23 @@
+import baseURL from '../baseURL';
+
+/**
+ * 인증 토큰 만료되면 refresh 토큰을 이용하여 새로운 인증 토큰을 발급받는 API
+ * @param {string} refreshToken
+ * @returns
+ */
+export async function refreshApi(refreshToken: string) {
+  try {
+    const response = await fetch(`${baseURL}/api/v1/login/refresh?refreshToken=${refreshToken}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!response.ok) {
+      throw new Error('토큰 갱신 실패');
+    }
+    return response.json();
+  } catch (error) {
+    console.error('토큰 갱신 실패', error);
+  }
+}

--- a/api/user/ticketsApi.ts
+++ b/api/user/ticketsApi.ts
@@ -14,7 +14,7 @@ async function getTickets(userToken: string) {
       },
     });
     if (!response.ok) {
-      console.error('응모권 불러오기 실패', response.status);
+      throw new Error('응모권 불러오기 실패');
     }
     return response.json();
   } catch (error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,8 @@
-'use client';
 import HomeMain from '../components/Home/HomeMain';
 import HeaderNav from '../components/Header/HeaderNav';
 import AuthHandler from '../components/AuthHandler';
-import useAuthStore from '../lib/store/useAuthStore';
 
 export default function HomePage() {
-  const { userToken } = useAuthStore((state) => ({
-    userToken: state.userToken,
-  }));
-
   return (
     <>
       <HeaderNav />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,14 @@
+'use client';
 import HomeMain from '../components/Home/HomeMain';
 import HeaderNav from '../components/Header/HeaderNav';
 import AuthHandler from '../components/AuthHandler';
+import useAuthStore from '../lib/store/useAuthStore';
 
 export default function HomePage() {
+  const { userToken } = useAuthStore((state) => ({
+    userToken: state.userToken,
+  }));
+
   return (
     <>
       <HeaderNav />

--- a/components/AuthHandler.tsx
+++ b/components/AuthHandler.tsx
@@ -2,11 +2,35 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
 import useAuthStore from '../lib/store/useAuthStore';
+import { refreshApi } from '../api/user/refreshApi';
 
 export default function AuthHandler() {
   const router = useRouter();
-  const setUserToken = useAuthStore((state) => state.setUserToken);
+  const { setUserToken, logout, refreshToken } = useAuthStore((state) => ({
+    setUserToken: state.setUserToken,
+    logout: state.logout,
+    refreshToken: state.refreshToken,
+  }));
+
+  const mutate = useMutation({
+    mutationKey: ['refreshToken'],
+    mutationFn: () => refreshApi(refreshToken),
+    onSuccess: (data) => {
+      const { jwt: accessToken } = data;
+      if (accessToken) {
+        localStorage.setItem('access_token', accessToken);
+        setUserToken(accessToken, refreshToken);
+      } else {
+        logout();
+      }
+    },
+    onError: (error) => {
+      console.error('토큰 갱신 실패', error);
+      logout();
+    },
+  });
 
   useEffect(() => {
     const url = new URL(window.location.href);
@@ -14,16 +38,29 @@ export default function AuthHandler() {
     const refreshToken = url.searchParams.get('refresh_token');
 
     /**
-     * 만약 accessToken과 refreshToken이 있다면 sessionStorage에 저장하고 setUserToken을 호출하여 accessToken과 refreshToken을 저장.
+     * @description
+     * 만약 accessToken과 refreshToken이 있다면 localStorage에 저장하고 setUserToken을 호출하여 accessToken과 refreshToken을 저장.
      * 그리고 router를 이용하여 홈으로 이동.
      */
     if (accessToken && refreshToken) {
-      sessionStorage.setItem('access_token', accessToken);
-      sessionStorage.setItem('refresh_token', refreshToken);
+      localStorage.setItem('access_token', accessToken);
+      localStorage.setItem('refresh_token', refreshToken);
       setUserToken(accessToken, refreshToken);
       router.replace('/');
     }
   }, [router, setUserToken]);
+
+  useEffect(() => {
+    if (!refreshToken) return;
+    const intervalId = setInterval(
+      () => {
+        mutate.mutate();
+      },
+      15 * 60 * 1000,
+    );
+
+    return () => clearInterval(intervalId);
+  }, [mutate, refreshToken]);
 
   return null;
 }


### PR DESCRIPTION
# overview
- 인증 토큰 만료되면 refresh 토큰을 이용하여 새로운 인증 토큰을 발급받는 API 기능 추가(refreshApi)
- refreshApi를 호출하여 refreshToken을 활용해서 새로운 accessToken을 발급받고, 이를 로컬 스토리지에 저장한다. 만약 토큰 갱신에 실패하면 로그아웃이 수행되도록 기능 구현