### PR TITLE
fix: myInfo, tickets API 함수에서 401 에러가 발생한다면 로그아웃 되도록하여 문제 해결

### DIFF
--- a/api/user/myInfoApi.ts
+++ b/api/user/myInfoApi.ts
@@ -1,6 +1,9 @@
 import baseURL from '../baseURL';
+import useAuthStore from '../../lib/store/useAuthStore';
 
 export async function getMyInfo(userToken: string) {
+  const { logout } = useAuthStore.getState();
+
   try {
     const response = await fetch(`${baseURL}/api/v1/user/mypage`, {
       method: 'GET',
@@ -12,8 +15,13 @@ export async function getMyInfo(userToken: string) {
     if (!response.ok) {
       throw new Error(`마이페이지 불러오기 실패: ${response.statusText}`);
     }
+    if (response.status === 401) {
+      console.error('인증 실패: 토큰이 만료되었습니다.');
+      logout();
+      return;
+    }
     return response.json();
   } catch (error) {
-    console.error('마이페이지 불러오기 실패', error);
+    throw new Error(`마이페이지 불러오기 실패: ${error}`);
   }
 }

--- a/api/user/ticketsApi.ts
+++ b/api/user/ticketsApi.ts
@@ -1,3 +1,4 @@
+import useAuthStore from '../../lib/store/useAuthStore';
 import baseURL from '../baseURL';
 
 /**
@@ -5,6 +6,7 @@ import baseURL from '../baseURL';
  * @param userToken
  */
 async function getTickets(userToken: string) {
+  const { logout } = useAuthStore.getState();
   try {
     const response = await fetch(`${baseURL}/api/v1/user/tickets`, {
       method: 'GET',
@@ -13,12 +15,17 @@ async function getTickets(userToken: string) {
         Authorization: `Bearer ${userToken}`,
       },
     });
+    if (response.status === 401) {
+      console.error('인증 실패: 토큰이 만료되었습니다.');
+      logout();
+      return;
+    }
     if (!response.ok) {
       throw new Error('응모권 불러오기 실패');
     }
     return response.json();
   } catch (error) {
-    console.error('응모권 불러오기 실패', error);
+    throw new Error(`응모권 불러오기 실패: ${error}`);
   }
 }
 
@@ -36,7 +43,7 @@ async function postTicketsPlusOne(userToken: string) {
     }
     return response.json();
   } catch (error) {
-    console.error('티켓 추가 실패', error);
+    throw new Error(`티켓 추가 실패: ${error}`);
   }
 }
 

--- a/components/AuthHandler.tsx
+++ b/components/AuthHandler.tsx
@@ -2,35 +2,13 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
 import useAuthStore from '../lib/store/useAuthStore';
-import { refreshApi } from '../api/user/refreshApi';
 
 export default function AuthHandler() {
   const router = useRouter();
-  const { setUserToken, logout, refreshToken } = useAuthStore((state) => ({
+  const { setUserToken } = useAuthStore((state) => ({
     setUserToken: state.setUserToken,
-    logout: state.logout,
-    refreshToken: state.refreshToken,
   }));
-
-  const mutate = useMutation({
-    mutationKey: ['refreshToken'],
-    mutationFn: () => refreshApi(refreshToken),
-    onSuccess: (data) => {
-      const { jwt: accessToken } = data;
-      if (accessToken) {
-        localStorage.setItem('access_token', accessToken);
-        setUserToken(accessToken, refreshToken);
-      } else {
-        logout();
-      }
-    },
-    onError: (error) => {
-      console.error('토큰 갱신 실패', error);
-      logout();
-    },
-  });
 
   useEffect(() => {
     const url = new URL(window.location.href);
@@ -49,18 +27,6 @@ export default function AuthHandler() {
       router.replace('/');
     }
   }, [router, setUserToken]);
-
-  useEffect(() => {
-    if (!refreshToken) return;
-    const intervalId = setInterval(
-      () => {
-        mutate.mutate();
-      },
-      15 * 60 * 1000,
-    );
-
-    return () => clearInterval(intervalId);
-  }, [mutate, refreshToken]);
 
   return null;
 }

--- a/lib/hooks/useMyInfo.ts
+++ b/lib/hooks/useMyInfo.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { getMyInfo } from '../../api/user/myInfo';
+import { useRouter } from 'next/navigation';
+import { getMyInfo } from '../../api/user/myInfoApi';
 import useAuthStore from '../store/useAuthStore';
 
 /**
@@ -8,13 +9,19 @@ import useAuthStore from '../store/useAuthStore';
  * @returns {string} userToken
  */
 export default function useMyInfo() {
+  const router = useRouter();
   const userToken = useAuthStore<string>((state) => state.userToken);
 
   const queryResult = useQuery({
     queryKey: ['getMyInfo'],
     queryFn: async () => {
       if (userToken) {
-        return await getMyInfo(userToken);
+        const data = await getMyInfo(userToken);
+        if (data?.error === '401') {
+          router.push('/');
+          return Promise.reject(new Error('인증 토큰이 만료되었습니다.'));
+        }
+        return data;
       }
       return Promise.reject(new Error('인증 토큰이 없습니다.'));
     },


### PR DESCRIPTION
## This PR contains:

- [x] bugfix
- [ ] feature
- [ ]  refactor
- [ ]  documentation
- [ ]  other


List any relevant issue numbers(selected):
#78 

## Description
- 유효한 인증토큰이 없어서 ticket 조회, 마이페이지 조회 API 함수에서 401에러가 하였습니다. 이를 해결하기 위해 API 함수안에 if 조건문으로 401에러가 발생한다면 로그아웃되도록 코드 수정하여 현재 문제를 수정하였습니다.
