### PR TITLE
fix: 로그인한 유저의 주소가 없을 때 마이페이지로 들어가면 발생하는 에러 수정

### DIFF
--- a/api/user/addressApi.ts
+++ b/api/user/addressApi.ts
@@ -16,6 +16,7 @@ export async function postAddress(addressData: PurchaseAddress, userToken: strin
     }
     return response;
   } catch (error) {
-    console.error('주소 등록 실패', error);
+    console.error('API Error:', error);
+    throw error;
   }
 }

--- a/api/user/phoneNumberApi.ts
+++ b/api/user/phoneNumberApi.ts
@@ -18,13 +18,13 @@ async function postPhoneNumber({
         phone_number: phoneNumber,
       }),
     });
-
     if (!response.ok) {
       throw new Error('전화번호 등록 실패');
     }
     return response;
   } catch (error) {
-    console.error('전화번호 등록 실패', error);
+    console.error('API Error:', error);
+    throw error;
   }
 }
 
@@ -52,7 +52,8 @@ async function postVerifyPhone({
     }
     return response.json();
   } catch (error) {
-    console.error('휴대폰 인증번호 요청 실패', error);
+    console.error('API Error:', error);
+    throw error;
   }
 }
 

--- a/app/myInfo/memberInfo/page.tsx
+++ b/app/myInfo/memberInfo/page.tsx
@@ -32,7 +32,7 @@ export default function MemberInfoPage() {
   }
 
   return (
-    <main className="flex flex-col items-center justify-center h-[40rem] p-4 sm:p-8">
+    <main className="flex flex-col items-center justify-center h-[50rem] p-4 sm:p-8">
       <section className="w-full bg-white p-8 rounded shadow-lg max-w-md sm:max-w-xl">
         <div className="flex flex-col items-center mb-4">
           <div className="w-auto h-auto bg-gray-400 rounded-full p-5 mb-5">
@@ -67,7 +67,7 @@ export default function MemberInfoPage() {
           ) : (
             <PhoneNumber />
           )}
-          {userData ? (
+          {userData?.address ? (
             <>
               <div className="w-full flex flex-col items-start gap-1 ">
                 <span className="text-gray-700 font-bold text-base sm:text-lg">우편주소</span>

--- a/components/AddressForm.tsx
+++ b/components/AddressForm.tsx
@@ -14,7 +14,7 @@ export default function AddressForm({
   handleRegisterAddress,
 }: AddressFormProps) {
   return (
-    <>
+    <div>
       <label htmlFor="address" className="text-gray-700 font-bold text-base">
         우편주소
       </label>
@@ -31,7 +31,7 @@ export default function AddressForm({
         />
         <Button
           type="button"
-          label="우편번호 찾기"
+          label="찾기"
           onClick={() => setIsPostcodeOpen(true)}
           width="auto"
           fontSize="base"
@@ -54,7 +54,7 @@ export default function AddressForm({
         />
         <Button
           type="button"
-          label="배송주소 등록"
+          label="등록"
           onClick={handleRegisterAddress}
           width="auto"
           fontSize="base"
@@ -73,6 +73,6 @@ export default function AddressForm({
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/components/payment/PhoneNumber.tsx
+++ b/components/payment/PhoneNumber.tsx
@@ -15,7 +15,7 @@ export default function PhoneNumber() {
   } = usePhoneNumber();
 
   return (
-    <>
+    <div>
       <label htmlFor="phoneNumber" className="text-gray-700 font-bold text-base">
         전화번호
       </label>
@@ -32,8 +32,8 @@ export default function PhoneNumber() {
         />
         <Button
           type="button"
-          label="인증번호 요청"
-          width="auto"
+          label="인증요청"
+          width="1/3"
           fontSize="base"
           onClick={handleVerifyPhoneNumber}
           disabled={isVerified}
@@ -57,7 +57,7 @@ export default function PhoneNumber() {
         />
         <Button
           type="button"
-          label="인증번호 확인"
+          label="확인"
           width="auto"
           fontSize="base"
           onClick={checkVerificationCode}
@@ -69,13 +69,13 @@ export default function PhoneNumber() {
         <Button
           type="button"
           label="전화번호 등록"
-          width="1/3"
+          width="auto"
           fontSize="base"
           onClick={handleRegisterPhoneNumber}
           disabled={!isVerified}
           className="text-white font-bold bg-primary hover:bg-blue-500"
         />
       </div>
-    </>
+    </div>
   );
 }

--- a/lib/hooks/useAddress.ts
+++ b/lib/hooks/useAddress.ts
@@ -44,7 +44,7 @@ export default function useAddress() {
     },
     onError: (error: Error) => {
       alert('주소 등록 실패');
-      throw error;
+      console.error('주소 등록 실패', error);
     },
   });
 

--- a/lib/hooks/useAddress.ts
+++ b/lib/hooks/useAddress.ts
@@ -48,7 +48,7 @@ export default function useAddress() {
     },
   });
 
-  const handleComplete = (data: DaumPostcodeAddress): void => {
+  const handleComplete = (data: DaumPostcodeAddress) => {
     let fullAddress = data.address;
     let extraAddress = '';
 
@@ -74,7 +74,7 @@ export default function useAddress() {
     setIsPostcodeOpen(false);
   };
 
-  const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+  const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setDetailAddress(event.target.value);
   };
 

--- a/lib/hooks/usePhoneNumber.ts
+++ b/lib/hooks/usePhoneNumber.ts
@@ -49,7 +49,7 @@ export default function usePhoneNumber() {
     },
   });
 
-  const checkVerificationCode = (): void => {
+  const checkVerificationCode = () => {
     if (!phoneNumber) {
       alert('전화번호를 입력해주세요');
       return;
@@ -66,7 +66,7 @@ export default function usePhoneNumber() {
     }
   };
 
-  const handleVerifyPhoneNumber = (): void => {
+  const handleVerifyPhoneNumber = () => {
     if (!/^\d{3}-\d{3,4}-\d{4}$/.test(phoneNumber)) {
       alert('전화번호를 입력해주세요');
       return;
@@ -74,7 +74,7 @@ export default function usePhoneNumber() {
     verifyPhoneNumberMutation.mutate();
   };
 
-  const handleRegisterPhoneNumber = (): void => {
+  const handleRegisterPhoneNumber = () => {
     if (!isVerified) {
       alert('휴대폰 인증을 완료해주세요');
       return;
@@ -82,7 +82,7 @@ export default function usePhoneNumber() {
     registerPhoneNumberMutation.mutate();
   };
 
-  const formatPhoneNumber = (value: string): string => {
+  const formatPhoneNumber = (value: string) => {
     const cleaned = value.replace(/\D/g, '');
     let formatted = '';
 
@@ -96,7 +96,7 @@ export default function usePhoneNumber() {
     return formatted;
   };
 
-  const handlePhoneNumberChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+  const handlePhoneNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const formattedPhoneNumber = formatPhoneNumber(event.target.value);
     setPhoneNumber(formattedPhoneNumber);
   };


### PR DESCRIPTION
## This PR contains:

- [x] bugfix
- [ ] feature
- [ ]  refactor
- [ ]  documentation
- [ ]  other


List any relevant issue numbers(selected):
#82 

## Description
- 로그인한 유저의 address가 null일때 마이페이지로 들어가면 address가 없다는 에러가 발생하였습니다.

` {userData?.address ? (
`
- 위 코드처럼 수정하여 userData의 address가 있을 때만 유저의 주소 조회하고 아니면 유저가 주소를 입력할 수 있는 폼을 보여주게 수정했습니다.

### Screen(selected)
수정 전
![image](https://github.com/user-attachments/assets/368e1db2-14ad-4f70-bad7-137b13c4d32c)

수정 후
![image](https://github.com/user-attachments/assets/00b8177f-1e7b-4d03-ade7-b8427553d2dd)

