### PR TITLE
feat: 유저가 응모한 래플 이력 조회해볼 수 있는 기능 구현 및 API 함수 반환 타입 추가

### DIFF
--- a/api/raffle/purchaseItemApi.ts
+++ b/api/raffle/purchaseItemApi.ts
@@ -1,12 +1,6 @@
 import baseURL from '../baseURL';
 
-export async function postPurchaseItem({
-  raffleId,
-  userToken,
-}: {
-  raffleId: number;
-  userToken: string;
-}) {
+async function postPurchaseItem({ raffleId, userToken }: { raffleId: number; userToken: string }) {
   try {
     const response = await fetch(`${baseURL}/api/v1/raffle/purchase/${raffleId}`, {
       method: 'POST',
@@ -23,3 +17,35 @@ export async function postPurchaseItem({
     console.error('상품 구매 실패', error);
   }
 }
+
+async function getPurchaseHistory({
+  userToken,
+  offset,
+  size,
+}: {
+  userToken: string;
+  offset?: number;
+  size?: number;
+}) {
+  try {
+    const response = await fetch(
+      `${baseURL}/api/v1/purchase_history?offset=${offset}&size=${size}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error('구매 내역 조회 실패');
+    }
+    return response.json();
+  } catch (error) {
+    console.error('구매 내역 조회 실패', error);
+  }
+}
+
+export { postPurchaseItem, getPurchaseHistory };

--- a/api/raffle/purchaseItemApi.ts
+++ b/api/raffle/purchaseItemApi.ts
@@ -1,3 +1,4 @@
+import { PurchaseHistoryResponse } from '../../lib/types/purchase';
 import baseURL from '../baseURL';
 
 async function postPurchaseItem({ raffleId, userToken }: { raffleId: number; userToken: string }) {
@@ -24,9 +25,9 @@ async function getPurchaseHistory({
   size,
 }: {
   userToken: string;
-  offset?: number;
-  size?: number;
-}) {
+  offset: number;
+  size: number;
+}): Promise<PurchaseHistoryResponse> {
   try {
     const response = await fetch(
       `${baseURL}/api/v1/purchase_history?offset=${offset}&size=${size}`,
@@ -38,13 +39,12 @@ async function getPurchaseHistory({
         },
       },
     );
-
     if (!response.ok) {
       throw new Error('구매 내역 조회 실패');
     }
     return response.json();
   } catch (error) {
-    console.error('구매 내역 조회 실패', error);
+    throw error;
   }
 }
 

--- a/api/user/addressApi.ts
+++ b/api/user/addressApi.ts
@@ -1,7 +1,10 @@
 import { PurchaseAddress } from '../../lib/types/purchase';
 import baseURL from '../baseURL';
 
-export async function postAddress(addressData: PurchaseAddress, userToken: string) {
+export async function postAddress(
+  addressData: PurchaseAddress,
+  userToken: string,
+): Promise<Response> {
   try {
     const response = await fetch(`${baseURL}/api/v1/user/set_address`, {
       method: 'POST',

--- a/api/user/myInfoApi.ts
+++ b/api/user/myInfoApi.ts
@@ -1,7 +1,8 @@
 import baseURL from '../baseURL';
 import useAuthStore from '../../lib/store/useAuthStore';
+import { getMyInfoResponse } from '../../lib/types/user';
 
-export async function getMyInfo(userToken: string) {
+export async function getMyInfo(userToken: string): Promise<getMyInfoResponse> {
   const { logout } = useAuthStore.getState();
 
   try {
@@ -18,7 +19,6 @@ export async function getMyInfo(userToken: string) {
     if (response.status === 401) {
       console.error('인증 실패: 토큰이 만료되었습니다.');
       logout();
-      return;
     }
     return response.json();
   } catch (error) {

--- a/api/user/phoneNumberApi.ts
+++ b/api/user/phoneNumberApi.ts
@@ -1,10 +1,10 @@
+import { VerifyPhoneResponse } from '../../lib/types/phone';
 import baseURL from '../baseURL';
 
 /**
  * @description 전화번호를 DB에 저장하는 API
  * @param {string} phoneNumber
  * @param {string} userToken
- * @returns
  */
 async function postPhoneNumber({
   phoneNumber,
@@ -34,13 +34,18 @@ async function postPhoneNumber({
   }
 }
 
+/**
+ * @description 전화번호 인증번호를 요청하는 API
+ * @param {string} phoneNumber
+ * @param {string} userToken
+ */
 async function postVerifyPhone({
   phoneNumber,
   userToken,
 }: {
   phoneNumber: string;
   userToken: string;
-}) {
+}): Promise<VerifyPhoneResponse> {
   try {
     const response = await fetch(`${baseURL}/api/v1/login/verify_phone`, {
       method: 'POST',

--- a/api/user/phoneNumberApi.ts
+++ b/api/user/phoneNumberApi.ts
@@ -1,12 +1,18 @@
 import baseURL from '../baseURL';
 
+/**
+ * @description 전화번호를 DB에 저장하는 API
+ * @param {string} phoneNumber
+ * @param {string} userToken
+ * @returns
+ */
 async function postPhoneNumber({
   phoneNumber,
   userToken,
 }: {
   phoneNumber: string;
   userToken: string;
-}) {
+}): Promise<Response> {
   try {
     const response = await fetch(`${baseURL}/api/v1/user/set_phoneNumber`, {
       method: 'POST',

--- a/api/user/ticketsApi.ts
+++ b/api/user/ticketsApi.ts
@@ -1,11 +1,12 @@
 import useAuthStore from '../../lib/store/useAuthStore';
+import { getTicketsResponse, postTicketsPlusOneResponse } from '../../lib/types/ticket';
 import baseURL from '../baseURL';
 
 /**
  * 유저의 응모권 갯수 가져오기
  * @param userToken
  */
-async function getTickets(userToken: string) {
+async function getTickets(userToken: string): Promise<getTicketsResponse> {
   const { logout } = useAuthStore.getState();
   try {
     const response = await fetch(`${baseURL}/api/v1/user/tickets`, {
@@ -18,7 +19,6 @@ async function getTickets(userToken: string) {
     if (response.status === 401) {
       console.error('인증 실패: 토큰이 만료되었습니다.');
       logout();
-      return;
     }
     if (!response.ok) {
       throw new Error('응모권 불러오기 실패');
@@ -29,7 +29,7 @@ async function getTickets(userToken: string) {
   }
 }
 
-async function postTicketsPlusOne(userToken: string) {
+async function postTicketsPlusOne(userToken: string): Promise<postTicketsPlusOneResponse> {
   try {
     const response = await fetch(`${baseURL}/api/v1/user/tickets/plus_one`, {
       method: 'POST',

--- a/api/user/ticketsApi.ts
+++ b/api/user/ticketsApi.ts
@@ -1,5 +1,4 @@
 import useAuthStore from '../../lib/store/useAuthStore';
-import { postTicketsPlusOneResponse } from '../../lib/types/ticket';
 import baseURL from '../baseURL';
 
 /**
@@ -29,7 +28,7 @@ async function getTickets(userToken: string): Promise<number> {
   }
 }
 
-async function postTicketsPlusOne(userToken: string): Promise<postTicketsPlusOneResponse> {
+async function postTicketsPlusOne(userToken: string): Promise<number> {
   try {
     const response = await fetch(`${baseURL}/api/v1/user/tickets/plus_one`, {
       method: 'POST',

--- a/api/user/ticketsApi.ts
+++ b/api/user/ticketsApi.ts
@@ -1,12 +1,12 @@
 import useAuthStore from '../../lib/store/useAuthStore';
-import { getTicketsResponse, postTicketsPlusOneResponse } from '../../lib/types/ticket';
+import { postTicketsPlusOneResponse } from '../../lib/types/ticket';
 import baseURL from '../baseURL';
 
 /**
  * 유저의 응모권 갯수 가져오기
  * @param userToken
  */
-async function getTickets(userToken: string): Promise<getTicketsResponse> {
+async function getTickets(userToken: string): Promise<number> {
   const { logout } = useAuthStore.getState();
   try {
     const response = await fetch(`${baseURL}/api/v1/user/tickets`, {

--- a/app/myInfo/purchaseHistory/page.tsx
+++ b/app/myInfo/purchaseHistory/page.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Image from 'next/image';
+import { getPurchaseHistory } from '../../../api/raffle/purchaseItemApi';
+import useAuthStore from '../../../lib/store/useAuthStore';
+
+export type PurchaseItems = {
+  id: number;
+  count: number;
+  isWinner: boolean;
+  raffle: {
+    id: number;
+    totalCount: number;
+    status: string;
+    completedDate: string;
+    ticketPrice: number;
+    item: {
+      id: number;
+      name: string;
+      category: string;
+      imageUrl: string;
+    };
+    winner?: {
+      name: string;
+    };
+  };
+};
+
+export default function PurchaseHistoryPage() {
+  const userToken = useAuthStore<string>((state) => state.userToken);
+  const [offset, setOffset] = useState<number>(0);
+  const [size] = useState<number>(10);
+
+  const {
+    data: purchaseItems,
+    isLoading,
+    isError,
+    error,
+  } = useQuery<PurchaseItems[]>({
+    queryKey: ['purchaseHistory', offset, size],
+    queryFn: () => getPurchaseHistory({ userToken, offset, size }),
+    enabled: !!userToken,
+  });
+
+  if (!userToken) {
+    return <div className="text-center py-8">로그인이 필요합니다.</div>;
+  }
+
+  if (isLoading) {
+    return <div className="text-center py-8">로딩 중...</div>;
+  }
+
+  if (isError) {
+    return (
+      <div className="text-center py-8 text-red-500">
+        오류 발생: {error instanceof Error ? error.message : '알 수 없는 오류'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h2 className="text-3xl font-bold mb-6 text-primary">래플 이력</h2>
+      {purchaseItems && purchaseItems.length > 0 ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          {purchaseItems.map((purchaseItem) => (
+            <div
+              key={purchaseItem.raffle.id}
+              className="bg-white rounded-md shadow-md overflow-hidden"
+            >
+              <div className="relative">
+                <Image
+                  src={purchaseItem.raffle.item.imageUrl}
+                  alt={purchaseItem.raffle.item.name}
+                  width={500}
+                  height={200}
+                  className="w-full h-60 object-cover"
+                  priority
+                />
+                <div className="absolute top-0 left-0 bg-black bg-opacity-50 text-white px-2 py-1 text-lg">
+                  {purchaseItem.raffle.status === 'COMPLETED'
+                    ? purchaseItem.isWinner
+                      ? '당첨'
+                      : '낙첨'
+                    : '추첨 전'}
+                </div>
+                <div className="absolute bottom-0 right-0 bg-white bg-opacity-75 px-2 py-1 text-lg">
+                  응모 수: {purchaseItem.count}
+                </div>
+              </div>
+              <div className="p-4">
+                <h3 className="text-lg font-semibold mb-2">{purchaseItem.raffle.item.name}</h3>
+                <p className="mb-1">{purchaseItem.raffle.id}번 래플</p>
+                <p className="mb-1">가격: {purchaseItem.raffle.ticketPrice}원</p>
+                {purchaseItem.raffle.status === 'COMPLETED' && (
+                  <p className="font-medium">
+                    {purchaseItem.isWinner
+                      ? '아쉽게도 당첨되지 않았습니다.'
+                      : `당첨자: ${purchaseItem.raffle.winner?.name}`}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-8 text-gray-500">구매 내역이 없습니다.</div>
+      )}
+    </div>
+  );
+}

--- a/app/myInfo/purchaseHistory/page.tsx
+++ b/app/myInfo/purchaseHistory/page.tsx
@@ -5,28 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import { getPurchaseHistory } from '../../../api/raffle/purchaseItemApi';
 import useAuthStore from '../../../lib/store/useAuthStore';
-
-export type PurchaseItems = {
-  id: number;
-  count: number;
-  isWinner: boolean;
-  raffle: {
-    id: number;
-    totalCount: number;
-    status: string;
-    completedDate: string;
-    ticketPrice: number;
-    item: {
-      id: number;
-      name: string;
-      category: string;
-      imageUrl: string;
-    };
-    winner?: {
-      name: string;
-    };
-  };
-};
+import { PurchaseHistoryResponse } from '../../../lib/types/purchase';
 
 export default function PurchaseHistoryPage() {
   const userToken = useAuthStore<string>((state) => state.userToken);
@@ -38,7 +17,7 @@ export default function PurchaseHistoryPage() {
     isLoading,
     isError,
     error,
-  } = useQuery<PurchaseItems[]>({
+  } = useQuery<PurchaseHistoryResponse>({
     queryKey: ['purchaseHistory', offset, size],
     queryFn: () => getPurchaseHistory({ userToken, offset, size }),
     enabled: !!userToken,

--- a/components/Header/HeaderNav.tsx
+++ b/components/Header/HeaderNav.tsx
@@ -21,26 +21,27 @@ export default function HeaderNav() {
    * 사용자 응모권 갯수를 나타내는 useQuery
    * !!enabled: userToken이 존재할 때만 실행
    */
-  const { data, isLoading } = useQuery({
+  const { data: ticketsCount, isLoading } = useQuery({
     queryKey: ['getTickets'],
     queryFn: () => getTickets(userToken),
     enabled: !!userToken,
   });
+
   if (isLoading) return <div>Loading...</div>;
 
-  const handleProfileClick = (): void => {
+  const handleProfileClick = () => {
     setIsPopverOpen(!isPopverOpen);
   };
 
-  const handleClosePopver = (): void => {
+  const handleClosePopver = () => {
     setIsPopverOpen(false);
   };
 
-  const handleNavDropDown = (): void => {
+  const handleNavDropDown = () => {
     setToggle(!toggle);
   };
 
-  const closeMenu = (): void => {
+  const closeMenu = () => {
     setToggle(false);
   };
 
@@ -94,7 +95,7 @@ export default function HeaderNav() {
             {userToken && (
               <div className="flex gap-2 justify-center py-2 px-4 w-full">
                 <img src="/icon/ticket.svg" alt="사용자 응모권 갯수" />
-                <span className="font-bold">{data}</span>
+                <span className="font-bold">{ticketsCount}</span>
               </div>
             )}
           </li>

--- a/components/Items/ItemDetail.tsx
+++ b/components/Items/ItemDetail.tsx
@@ -81,7 +81,7 @@ export default function ItemDetail({ params: { id } }: { params: { id: number } 
     if (!userToken) {
       setIsLoginModalOpen(true);
     } else {
-      if (ticketsCount > 0) {
+      if (ticketsCount !== undefined && ticketsCount > 0) {
         mutate.mutate();
       } else {
         alert('응모권이 부족합니다.');

--- a/components/Items/ItemStyle.tsx
+++ b/components/Items/ItemStyle.tsx
@@ -64,7 +64,7 @@ export default function ItemStyle({
     staleTime: 1000 * 60,
   });
 
-  const handleImageClick = (event: React.MouseEvent): void => {
+  const handleImageClick = (event: React.MouseEvent) => {
     if (status === 'COMPLETED') {
       event.preventDefault();
       setIsModalOpen(!isModalOpen);
@@ -74,7 +74,7 @@ export default function ItemStyle({
   /**
    * 응모하기 버튼 클릭 시 실행되는 함수
    */
-  const handleEnterRaffle = (): void => {
+  const handleEnterRaffle = () => {
     if (!userToken) {
       setIsLoginModalOpen(true);
     } else {
@@ -87,7 +87,7 @@ export default function ItemStyle({
       } else if (!userData.address.address || !userData.address.detail) {
         setIsAddressModalOpen(true);
         return;
-      } else if (ticketsCount > 0) {
+      } else if (typeof ticketsCount === 'number' && ticketsCount > 0) {
         mutate.mutate();
         setIsRaffleConfirmationModalOpen(true);
       } else {
@@ -96,7 +96,7 @@ export default function ItemStyle({
     }
   };
 
-  const handleCloseRaffleConfirmationModal = (): void => {
+  const handleCloseRaffleConfirmationModal = () => {
     if (!userToken) {
       setIsLoginModalOpen(false);
     } else {

--- a/components/MyInfoStyle.tsx
+++ b/components/MyInfoStyle.tsx
@@ -41,14 +41,17 @@ export default function MyInfoStyle({ userData }: { userData: UserData }) {
             </div>
             <span>&gt;</span>
           </li>
-          <li className="w-full sm:w-2/3 flex items-center justify-between py-2 px-4 bg-white border border-gray-300 rounded hover:bg-gray-100 cursor-pointer">
+          <li
+            className="w-full sm:w-2/3 flex items-center justify-between py-2 px-4 bg-white border border-gray-300 rounded hover:bg-gray-100 cursor-pointer"
+            onClick={() => router.push('/myInfo/purchaseHistory')}
+          >
             <div className="flex gap-2">
               <img
                 src="/icon/submissionHistory.svg"
-                alt="응모 이력 아이콘"
+                alt="래플 이력 아이콘"
                 className="w-4 sm:w-5 h-auto"
               />
-              <h4 className="text-base sm:text-lg">응모 이력</h4>
+              <h4 className="text-base sm:text-lg">래플 이력</h4>
             </div>
             <span>&gt;</span>
           </li>

--- a/lib/hooks/useMyInfo.ts
+++ b/lib/hooks/useMyInfo.ts
@@ -1,14 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { getMyInfo } from '../../api/user/myInfoApi';
 import useAuthStore from '../store/useAuthStore';
+import { getMyInfoResponse } from '../types/user';
 
 /**
  * @description 사용자의 정보를 나타내는 커스텀 훅
  * @returns {object} queryResult
  * @returns {string} userToken
  */
-export default function useMyInfo() {
+export default function useMyInfo(): UseQueryResult<getMyInfoResponse, Error> & {
+  userToken: string;
+} {
   const router = useRouter();
   const userToken = useAuthStore<string>((state) => state.userToken);
 

--- a/lib/types/phone.ts
+++ b/lib/types/phone.ts
@@ -1,0 +1,4 @@
+export type VerifyPhoneResponse = {
+  phoneNumber: string;
+  secretKey: string;
+};

--- a/lib/types/purchase.ts
+++ b/lib/types/purchase.ts
@@ -24,3 +24,28 @@ export type DaumPostcodeAddress = BaseAddress & {
   addressType: string;
   query: string;
 };
+
+/**
+ * @description 래플 이력 조회 함수 API 응답 타입
+ */
+export type PurchaseHistoryResponse = {
+  id: number;
+  count: number;
+  isWinner: boolean;
+  raffle: {
+    id: number;
+    totalCount: number;
+    status: string;
+    completedDate: string;
+    ticketPrice: number;
+    item: {
+      id: number;
+      name: string;
+      category: string;
+      imageUrl: string;
+    };
+    winner?: {
+      name: string;
+    };
+  };
+}[];

--- a/lib/types/ticket.ts
+++ b/lib/types/ticket.ts
@@ -1,3 +1,0 @@
-export type postTicketsPlusOneResponse = {
-  tickets: number;
-};

--- a/lib/types/ticket.ts
+++ b/lib/types/ticket.ts
@@ -1,0 +1,7 @@
+export type postTicketsPlusOneResponse = {
+  tickets: number;
+};
+
+export type getTicketsResponse = {
+  tickets: number;
+};

--- a/lib/types/ticket.ts
+++ b/lib/types/ticket.ts
@@ -3,5 +3,5 @@ export type postTicketsPlusOneResponse = {
 };
 
 export type getTicketsResponse = {
-  tickets: number;
+  tickets: string;
 };

--- a/lib/types/ticket.ts
+++ b/lib/types/ticket.ts
@@ -1,7 +1,3 @@
 export type postTicketsPlusOneResponse = {
   tickets: number;
 };
-
-export type getTicketsResponse = {
-  tickets: string;
-};

--- a/lib/types/user.ts
+++ b/lib/types/user.ts
@@ -15,3 +15,23 @@ export type UserData = {
     detail: string;
   };
 };
+
+export type getMyInfoResponse = {
+  name: string;
+  email: string;
+  phoneNumber: string;
+  address: {
+    address: string;
+    addressEnglish: string;
+    bname: string;
+    jibunAddress: string;
+    jibunAddressEnglish: string;
+    roadAddress: string;
+    sido: string;
+    sigungu: string;
+    query: string;
+    detail: string;
+    postalCode: string;
+  };
+  error?: string;
+};


### PR DESCRIPTION
- [ ] bugfix
- [x] feature
- [x]  refactor
- [ ]  documentation
- [ ]  other

## Description
### API 응답 및 타입 개선:
- api/raffle/purchaseItemApi.ts: getPurchaseHistory 함수 추가하여 구매 이력 조회 기능 구현
- api/user/addressApi.ts: postAddress 함수가 Promise<Response>를 반환하도록 수정.
- api/user/myInfoApi.ts: getMyInfo 함수가 Promise<getMyInfoResponse>를 반환하도록 수정.
- api/user/phoneNumberApi.ts: JSDoc 주석 추가, postPhoneNumber와 postVerifyPhone 함수가 각각 Promise<Response>와 Promise<VerifyPhoneResponse>를 반환하도록 수정.
- api/user/ticketsApi.ts: getTickets와 postTicketsPlusOne 함수가 Promise<number>를 반환하도록 수정.

### 새로운 기능:
- app/myInfo/purchaseHistory/page.tsx: getPurchaseHistory API를 사용해 구매 이력을 표시하는 페이지 추가.

### 코드 개선:
- components/Header/HeaderNav.tsx: data 변수를 ticketsCount로 변경해 명확성 향상, 불필요한 타입 주석 제거.
- components/Items/ItemDetail.tsx: ticketsCount가 정의되어 있는지 확인하는 로직 추가.
- components/Items/ItemStyle.tsx: 불필요한 타입 주석 제거, ticketsCount에 대한 타입 체크 추가.
- components/MyInfoStyle.tsx: 클릭 시 구매 이력 페이지로 이동하는 핸들러 추가.

### 타입 정의:
- lib/types/phone.ts: VerifyPhoneResponse 타입 추가.
- lib/types/purchase.ts: PurchaseHistoryResponse 타입 추가하여 구매 이력 데이터 구조 정의.
- lib/types/user.ts: getMyInfoResponse 타입 추가하여 사용자 정보 데이터 구조 정의.

### Screen(selected)
![image](https://github.com/user-attachments/assets/4a8e3b20-1089-405a-a623-b1b3baa542a9)
