### PR TITLE
feat: 응모한 상품의 당첨내역과 리뷰 내역을 볼 수 있는 당첨 내역 페이지 구현

### DIFF
--- a/api/history/purchaseHistoryApi.ts
+++ b/api/history/purchaseHistoryApi.ts
@@ -1,0 +1,31 @@
+import { PurchaseHistoryResponse } from '../../lib/types/purchase';
+import baseURL from '../baseURL';
+
+export async function getPurchaseHistory({
+  userToken,
+  offset,
+  size,
+}: {
+  userToken: string;
+  offset: number;
+  size: number;
+}): Promise<PurchaseHistoryResponse> {
+  try {
+    const response = await fetch(
+      `${baseURL}/api/v1/purchase_history?offset=${offset}&size=${size}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error('구매 내역 조회 실패');
+    }
+    return response.json();
+  } catch (error) {
+    throw error;
+  }
+}

--- a/api/history/winnerHistoryApi.ts
+++ b/api/history/winnerHistoryApi.ts
@@ -1,0 +1,27 @@
+import baseURL from '../baseURL';
+
+export async function getWinnerHistory({
+  userToken,
+  cursor,
+  size,
+}: {
+  userToken: string;
+  cursor: number;
+  size: number;
+}) {
+  try {
+    const response = await fetch(`${baseURL}/api/v1/winner_history?cursor=${cursor}&size=${size}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${userToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!response.ok) {
+      throw new Error('구매 내역 조회 실패');
+    }
+    return response.json();
+  } catch (error) {
+    throw error;
+  }
+}

--- a/api/raffle/purchaseItemApi.ts
+++ b/api/raffle/purchaseItemApi.ts
@@ -1,4 +1,3 @@
-import { PurchaseHistoryResponse } from '../../lib/types/purchase';
 import baseURL from '../baseURL';
 
 async function postPurchaseItem({ raffleId, userToken }: { raffleId: number; userToken: string }) {
@@ -19,33 +18,4 @@ async function postPurchaseItem({ raffleId, userToken }: { raffleId: number; use
   }
 }
 
-async function getPurchaseHistory({
-  userToken,
-  offset,
-  size,
-}: {
-  userToken: string;
-  offset: number;
-  size: number;
-}): Promise<PurchaseHistoryResponse> {
-  try {
-    const response = await fetch(
-      `${baseURL}/api/v1/purchase_history?offset=${offset}&size=${size}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${userToken}`,
-          'Content-Type': 'application/json',
-        },
-      },
-    );
-    if (!response.ok) {
-      throw new Error('구매 내역 조회 실패');
-    }
-    return response.json();
-  } catch (error) {
-    throw error;
-  }
-}
-
-export { postPurchaseItem, getPurchaseHistory };
+export { postPurchaseItem };

--- a/app/myInfo/purchaseHistory/page.tsx
+++ b/app/myInfo/purchaseHistory/page.tsx
@@ -3,9 +3,9 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
-import { getPurchaseHistory } from '../../../api/raffle/purchaseItemApi';
 import useAuthStore from '../../../lib/store/useAuthStore';
 import { PurchaseHistoryResponse } from '../../../lib/types/purchase';
+import { getPurchaseHistory } from '../../../api/history/purchaseHistoryApi';
 
 export default function PurchaseHistoryPage() {
   const userToken = useAuthStore<string>((state) => state.userToken);

--- a/app/myInfo/winnerHistory/page.tsx
+++ b/app/myInfo/winnerHistory/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import { getWinnerHistory } from '../../../api/history/winnerHistoryApi';
+import useAuthStore from '../../../lib/store/useAuthStore';
+
+export default function WinnerHistoryPage() {
+  const userToken = useAuthStore<string>((state) => state.userToken);
+  const [cursor, setCursor] = useState<number>(0);
+  const [size] = useState<number>(5);
+  const {
+    data: winnerData,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['getWinnerHistory'],
+    queryFn: () => getWinnerHistory({ userToken, cursor, size }),
+    enabled: !!userToken,
+  });
+
+  if (isLoading) return <div>Loading...</div>;
+
+  if (isError)
+    return <div>Error: {error instanceof Error ? error.message : JSON.stringify(error)}</div>;
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h2 className="text-3xl font-bold mb-6 text-primary">당첨 내역</h2>
+      {winnerData && winnerData.length > 0 ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          {winnerData.map((winner: any) => (
+            <div key={winner.raffle.id} className="bg-white rounded-md shadow-md overflow-hidden">
+              <div className="relative">
+                <img
+                  src={winner.raffle.item.imageUrl}
+                  alt={winner.raffle.item.name}
+                  className="w-full h-60 object-cover"
+                />
+              </div>
+              <div className="p-4">
+                <h3 className="text-xl font-semibold">{winner.raffle.item.name}</h3>
+                <p className="text-gray-600">{winner.raffle.item.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-8">당첨 내역이 없습니다.</div>
+      )}
+    </div>
+  );
+}

--- a/components/MyInfoStyle.tsx
+++ b/components/MyInfoStyle.tsx
@@ -43,6 +43,20 @@ export default function MyInfoStyle({ userData }: { userData: UserData }) {
           </li>
           <li
             className="w-full sm:w-2/3 flex items-center justify-between py-2 px-4 bg-white border border-gray-300 rounded hover:bg-gray-100 cursor-pointer"
+            onClick={() => router.push('/myInfo/winnerHistory')}
+          >
+            <div className="flex gap-2">
+              <img
+                src="/icon/submissionHistory.svg"
+                alt="래플 이력 아이콘"
+                className="w-4 sm:w-5 h-auto"
+              />
+              <h4 className="text-base sm:text-lg">당첨 내역</h4>
+            </div>
+            <span>&gt;</span>
+          </li>
+          <li
+            className="w-full sm:w-2/3 flex items-center justify-between py-2 px-4 bg-white border border-gray-300 rounded hover:bg-gray-100 cursor-pointer"
             onClick={() => router.push('/myInfo/purchaseHistory')}
           >
             <div className="flex gap-2">


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [x] feature
- [ ]  refactor
- [ ]  documentation
- [ ]  other


## Description
- getWinnerHistory API를 사용하여 당첨 내역을 표시하는 새로운 페이지를 구현했습니다.
- purchaseHistory API 함수 파일 모듈화되도록 분리하였습니다.


### Screen(selected)
![image](https://github.com/user-attachments/assets/be838f37-512d-4e68-8ecb-b99429dda648)
![image](https://github.com/user-attachments/assets/1a5f97f8-d8b4-4640-941a-a63ca6a53388)
